### PR TITLE
Fixing dual window outputs

### DIFF
--- a/pub/js/rules.js
+++ b/pub/js/rules.js
@@ -166,7 +166,7 @@ Rules.section203Analysis = function () {
         Rules.addFlag('A.ii.a');
       }
     }
-    if (Values.pub_right != 'yes') {
+    if (Values.pub_right == undefined) {
       Values.p_term_begin = Values.k_year + 40;
       if (Values.pub_year != undefined) {
         Values.p_term_begin = Math.min(Values.pub_year + 35,


### PR DESCRIPTION
Presently, the tool creates dual-window outputs for all post 78 results where the p_right is not affirmatively marked as "yes." Instead, should only happen where p_right is "don't know" (i.e., undefined).

NOTE/WARNING: I'm not really sure how the values are passed from the question to the test here. Essentially, we only want to pick up the "maybe" answer here. So the appropriate fix might be to set this change to == 'maybe' rather than == undefined.