### PR TITLE
Black hole grant fix

### DIFF
--- a/pub/js/rules.js
+++ b/pub/js/rules.js
@@ -90,7 +90,7 @@ Rules.section304Analysis = function () {
   if (Values.k_year < 1978) {
     result = 's2q2a';
     Rules.addFlag('F.i');
-    if ((Values.pub_year == undefined) && (Values.reg_year == undefined)) {
+    if ((Values.pub_year > 1977) && (Values.reg_year > 1977)) {
       result = Rules.conclusion('B.vii');
     } else {
       // Under the 1909 Act, copyright term begins at the earlier of


### PR DESCRIPTION
I thought this was already done for some reason, but it doesn't appear to be?

Essentially, this throws negative result under Section 304 where a work was transferred before 78 but was only copyrighted after 78. The test for never published / never registered works should still run on 291.