### PR TITLE
move questions init function to questions.js

### DIFF
--- a/wordpress-plugin/index.php
+++ b/wordpress-plugin/index.php
@@ -66,12 +66,6 @@ $tot_tool_html = <<<'EOD'
            class="btn btn-default hidden"
            id="button-restart">Restart</a>
       </div>
-
-    <script>
-      jQuery( document ).ready(function () {
-        Questions.start();
-      });
-    </script>
 EOD;
 
 

--- a/wordpress-plugin/js/questions.js
+++ b/wordpress-plugin/js/questions.js
@@ -474,3 +474,7 @@ Questions.start = function () {
   Questions.transitionQuestion(Questions.first_question);
   Values.question_id = Questions.first_question;
 };
+
+jQuery( document ).ready(function () {
+  Questions.start();
+});


### PR DESCRIPTION
## Description
This PR changes the way to initialize questions on this plugin. `Questions.start()` 

## Technical details
The function was initialized in the markup of the WordPress shortcode. Regardless the fact of this is not a good practice it seems to be called before jquery was included. 
I move the init function to `questions.js` which make more sense and we ensure the execution of the function once jquery is included

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
